### PR TITLE
feat: add oauth2 flow to obtain access_token

### DIFF
--- a/docs/examples/authenticate.py
+++ b/docs/examples/authenticate.py
@@ -1,0 +1,16 @@
+import pawl
+
+linkedin = pawl.Linkedin(
+    client_id="",  # provide client_id here
+    client_secret="",  # provide client_secret here
+    redirect_uri="http://localhost:8000",
+)
+
+url = linkedin.auth.url()
+print("click here", url)
+
+code = input("Enter code: ")
+
+print("Authorizing...")
+print(linkedin.auth.authorize(code))
+print(f"Basic Profile Data: {linkedin.current_user.basic_profile()}")

--- a/pawl/core/auth.py
+++ b/pawl/core/auth.py
@@ -1,16 +1,131 @@
 """Provides Authentication and Authorization classes."""
+from enum import Enum
+from requests import Request
+from requests.status_codes import codes
+import time
+from urllib.parse import quote
+
+from . import constants
+from .exceptions import InvalidInvocation, OAuthException, ResponseException  # noqa
+
+
+class AuthPermissions(Enum):
+    BASIC_PROFILE = "r_liteprofile"
+    EMAIL_ADDRESS = "r_emailaddress"
+    MEMBER_SOCIAL = "w_member_social"
+
+    @staticmethod
+    def to_oauth_scope():
+        return (" ").join([scope.value for scope in list(AuthPermissions)])
 
 
 class BaseAuthenticator:
     """Provide the base authenticator object that stores OAuth2 credentials."""
 
-    ...
+    def __init__(self, requestor, client_id, redirect_uri=None):
+        self._requestor = requestor
+        self.client_id = client_id
+        self.redirect_uri = redirect_uri
+
+    def _post(self, url, success_status=codes["ok"], **data):
+        response = self._requestor.request(
+            "POST",
+            url,
+            data=data,
+            headers={
+                "Connection": "close",
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+        )
+        if response.status_code != success_status:
+            raise ResponseException(response)
+        return response
+
+    def authorize_url(self, scopes, state):
+        """Return the URL used out-of-band to grant access to your application.
+
+        :param scopes: A list of OAuth scopes to request authorization for.
+        :param state: A string that will be reflected in the callback to
+            ``redirect_uri``. Elements must be printable ASCII characters in the range
+            0x20 through 0x7E inclusive. This value should be temporarily unique to the
+            client for whom the URL was generated.
+        """
+        if self.redirect_uri is None:
+            raise InvalidInvocation("redirect URI not provided")
+        params = self._prepare_params(
+            {
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "response_type": "code",
+                "scope": " ".join(scopes),
+                "state": state,
+            }
+        )
+        url = self._requestor.oauth_url + constants.AUTHORIZATION_PATH
+        request = Request("GET", f"{url}?{params}")
+        return request.prepare().url
+
+    @staticmethod
+    def _prepare_params(params: dict[str]) -> str:
+        """Handle scope spacing for Linkedin API.
+
+        WIP
+        """
+        params_list = [f"{quote(key)}={quote(value)}" for key, value in params.items()]
+        return "&".join(params_list)
+
+
+class Authenticator(BaseAuthenticator):
+    """Store OAuth2 authentication credentials for web, or script type apps."""
+
+    RESPONSE_TYPE = "code"
+
+    def __init__(self, requestor, client_id, client_secret, redirect_uri=None):
+        super(Authenticator, self).__init__(requestor, client_id, redirect_uri)
+        self.client_secret = client_secret
 
 
 class BaseAuthorizer:
     """Superclass for OAuth2 authorization tokens and scopes."""
 
-    ...
+    def __init__(self, authenticator: Authenticator):
+        self._authenticator = authenticator
+        self._clear_access_token()
+        self._validate_authenticator()
+
+    def _clear_access_token(self):
+        self._expiration_timestamp = None
+        self.access_token = None
+
+    def _validate_authenticator(self):
+        if not isinstance(self._authenticator, self.AUTHENTICATOR_CLASS):
+            raise InvalidInvocation(
+                "Must use a authenticator of type"
+                f" {self.AUTHENTICATOR_CLASS.__name__}."
+            )
+
+    def is_valid(self):
+        """Return whether or not the Authorizer is ready to authorize requests.
+
+        A ``True`` return value does not guarantee that the access_token is actually
+        valid on the server side.
+        """
+        return (
+            self.access_token is not None and time.time() < self._expiration_timestamp
+        )
+
+    def _request_token(self, **data):
+        url = self._authenticator._requestor.oauth_url + constants.ACCESS_TOKEN_PATH
+        pre_request_time = time.time()
+        response = self._authenticator._post(url, **data)
+
+        # TODO - Create abstract payload class
+        payload = response.json()
+        self._expiration_timestamp = pre_request_time - 10 + payload["expires_in"]
+        self.access_token = payload["access_token"]
+        # Not supported
+        # if "refresh_token" in payload:
+        #     self.refresh_token = payload["refresh_token"]
 
 
 class Authorizer(BaseAuthorizer):
@@ -26,10 +141,37 @@ class Authorizer(BaseAuthorizer):
         refresh_token=None,
     ):
         """Authorize access to Linkedin's API."""
-        ...
+        super(Authorizer, self).__init__(authenticator)
+        self._post_refresh_callback = post_refresh_callback
+        self._pre_refresh_callback = pre_refresh_callback
+        self.refresh_token = refresh_token
 
+    def authorize(self, code: str):
+        """Obtain and set authorization tokens based on ``code``.
 
-class Authenticator(BaseAuthenticator):
-    """Store OAuth2 authentication credentials for web, or script type apps."""
+        :param code: The code obtained by an out-of-band authorization request to
+            Linkedin.
+        """
+        if self._authenticator.redirect_uri is None:
+            raise InvalidInvocation("redirect URI not provided")
+        self._request_token(
+            grant_type="authorization_code",
+            code=code,
+            client_id=self._authenticator.client_id,
+            client_secret=self._authenticator.client_secret,
+            redirect_uri=self._authenticator.redirect_uri,
+        )
 
-    ...
+    # Only supported for certain platforms
+    # Reference: https://docs.microsoft.com/en-us/linkedin/shared/authentication/programmatic-refresh-tokens?context=linkedin/marketing/context # noqa
+    # def refresh(self):
+    #     """Obtain a new access token from the refresh_token."""
+    #     if self._pre_refresh_callback:
+    #         self._pre_refresh_callback(self)
+    #     if self.refresh_token is None:
+    #         raise InvalidInvocation("refresh token not provided")
+    #     self._request_token(
+    #         grant_type="refresh_token", refresh_token=self.refresh_token
+    #     )
+    #     if self._post_refresh_callback:
+    #         self._post_refresh_callback(self)

--- a/pawl/core/constants.py
+++ b/pawl/core/constants.py
@@ -1,4 +1,7 @@
 """Constants for core."""
+import os
 
-ACCESS_TOKEN_PATH = "oauth/v2/accessToken"
-AUTHORIZATION_PATH = "oauth/v2/authorization"
+ACCESS_TOKEN_PATH = "v2/accessToken"
+AUTHORIZATION_PATH = "v2/authorization"
+
+TIMEOUT = float(os.environ.get("pawl_timeout", 16))

--- a/pawl/core/exceptions.py
+++ b/pawl/core/exceptions.py
@@ -1,0 +1,161 @@
+"""Provide exception classes for the Core package."""
+
+
+class CoreException(Exception):
+    """Base exception class for exceptions that occur within this package."""
+
+
+class InvalidInvocation(CoreException):
+    """Indicate that the code to execute cannot be completed."""
+
+
+class RequestException(CoreException):
+    """Indicate that there was an error with the incomplete HTTP request."""
+
+    def __init__(self, original_exception, request_args, request_kwargs):
+        """Initialize a RequestException instance.
+
+        :param original_exception: The original exception that occurred.
+        :param request_args: The arguments to the request function.
+        :param request_kwargs: The keyword arguments to the request function.
+
+        """
+        self.original_exception = original_exception
+        self.request_args = request_args
+        self.request_kwargs = request_kwargs
+        super(RequestException, self).__init__(
+            f"error with request {original_exception}"
+        )
+
+
+class ResponseException(CoreException):
+    """Indicate that there was an error with the completed HTTP request."""
+
+    def __init__(self, response):
+        """Initialize a ResponseException instance.
+
+        :param response: A requests.response instance.
+
+        """
+        self.response = response
+        super(ResponseException, self).__init__(
+            f"received {response.status_code} HTTP response"
+        )
+
+
+class OAuthException(CoreException):
+    """Indicate that there was an OAuth2 related error with the request."""
+
+    def __init__(self, response, error, description):
+        """Initialize a OAuthException instance.
+
+        :param response: A requests.response instance.
+        :param error: The error type returned by Linkedin.
+        :param description: A description of the error when provided.
+
+        """
+        self.error = error
+        self.description = description
+        self.response = response
+        message = f"{error} error processing request"
+        if description:
+            message += f" ({description})"
+        CoreException.__init__(self, message)
+
+
+class BadJSON(ResponseException):
+    """Indicate the response did not contain valid JSON."""
+
+
+class BadRequest(ResponseException):
+    """Indicate invalid parameters for the request."""
+
+
+class Conflict(ResponseException):
+    """Indicate a conflicting change in the target resource."""
+
+
+class ExpiredToken(ResponseException):
+    """Indicate that the access token has expired."""
+
+
+class Forbidden(ResponseException):
+    """Indicate the authentication is not permitted for the request."""
+
+
+class InsufficientScope(ResponseException):
+    """Indicate that the request requires a different scope."""
+
+
+class InvalidToken(ResponseException):
+    """Indicate that the request used an invalid access token."""
+
+
+class MissingToken(ResponseException):
+    """Indicate that the request is missing an access token."""
+
+
+class NotFound(ResponseException):
+    """Indicate that the requested URL was not found."""
+
+
+class RevokedToken(ResponseException):
+    """Indicate that user's access token has been revoked by the member on Linkedin’s website."""
+
+
+class ServerError(ResponseException):
+    """Indicate issues on the server end preventing request fulfillment."""
+
+
+class SpecialError(ResponseException):
+    """Indicate syntax or spam-prevention issues."""
+
+    def __init__(self, response):
+        """Initialize a SpecialError exception instance.
+
+        :param response: A requests.response instance containing a message and a list of
+            special errors.
+
+        """
+        self.response = response
+
+        resp_dict = self.response.json()  # assumes valid JSON
+        self.message = resp_dict.get("message", "")
+        self.reason = resp_dict.get("reason", "")
+        self.special_errors = resp_dict.get("special_errors", [])
+        CoreException.__init__(self, f"Special error {self.message!r}")
+
+
+class TooLarge(ResponseException):
+    """Indicate that the request data exceeds the allowed limit."""
+
+
+class TooManyRequests(ResponseException):
+    """Indicate that the user has sent too many requests in a given amount of time."""
+
+    def __init__(self, response):
+        """Initialize a TooManyRequests exception instance.
+
+        :param response: A requests.response instance that may contain a retry-after
+        header and a message.
+
+        """
+        self.response = response
+        self.retry_after = response.headers.get("retry-after")
+        self.message = response.text  # Not all response bodies are valid JSON
+
+        msg = f"received {response.status_code} HTTP response"
+        if self.retry_after:
+            msg += (
+                f". Please wait at least {float(self.retry_after)} seconds "
+                "before re-trying this request."
+            )
+        CoreException.__init__(self, msg)
+
+
+class UnknownAuthSchema(ResponseException):
+    """Indicate unrecognized authentication header schema."""
+
+
+class URITooLong(ResponseException):
+    """Indicate that the length of the request URI exceeds the allowed limit."""

--- a/pawl/core/rate_limit.py
+++ b/pawl/core/rate_limit.py
@@ -1,0 +1,70 @@
+"""Provide the RateLimiter class."""
+import logging
+import time
+
+log = logging.getLogger(__package__)
+
+
+class RateLimiter:
+    def __init__(self):
+        """Create an instance of the RateLimit class."""
+        # TODO - Improve RateLimiter
+        self.remaining = 5000  # limits vary on action
+        self.next_request_timestamp = None
+        self.reset_timestamp = None
+        self.used = 0
+
+    def call(self, request_function, set_header_callback, *args, **kwargs):
+        """Rate limit the call to request_function.
+
+        :param request_function: A function call that returns an HTTP response object.
+        :param set_header_callback: A callback function used to set the request headers.
+            This callback is called after any necessary sleep time occurs.
+        :param args: The positional arguments to ``request_function``.
+        :param kwargs: The keyword arguments to ``request_function``.
+        """
+        self.delay()
+        kwargs["headers"] = set_header_callback()
+        response = request_function(*args, **kwargs)
+        self.update(response.headers)
+        return response
+
+    def delay(self):
+        """Sleep for an amount of time to remain under the rate limit."""
+        if self.next_request_timestamp is None:
+            return
+        sleep_seconds = self.next_request_timestamp - time.time()
+        if sleep_seconds <= 0:
+            return
+        message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to call"
+        log.debug(message)
+        time.sleep(sleep_seconds)
+
+    def update(self, response_headers):
+        """Update the state of the rate limiter based on the response headers.
+
+        This method should only be called following a HTTP request to Linkedin.
+        Response headers will be treated as a single request. This behavior is to
+        error on the safe-side as such responses should trigger exceptions
+        that indicate invalid behavior.
+        """
+        if self.remaining is not None:
+            self.remaining -= 1
+            self.used += 1
+            return
+
+        now = time.time()
+
+        seconds_to_reset = int(response_headers["x-ratelimit-reset"])
+        self.remaining = float(response_headers["x-ratelimit-remaining"])
+        self.used = int(response_headers["x-ratelimit-used"])
+        self.reset_timestamp = now + seconds_to_reset
+
+        if self.remaining <= 0:
+            self.next_request_timestamp = self.reset_timestamp
+            return
+
+        self.next_request_timestamp = min(
+            self.reset_timestamp,
+            now + max(min((seconds_to_reset - self.remaining) / 2, 10), 0),
+        )

--- a/pawl/core/requestor.py
+++ b/pawl/core/requestor.py
@@ -1,0 +1,49 @@
+"""Provides the HTTP request handling interface."""
+import requests
+
+from typing import Union
+
+from .constants import TIMEOUT
+from .exceptions import RequestException
+from .session import Session
+
+
+class Requestor:
+    """Requestor provides an interface to HTTP requests."""
+
+    def __getattr__(self, attribute):
+        """Pass all undefined attributes to the _http attribute."""
+        if attribute.startswith("__"):
+            raise AttributeError
+        return getattr(self._http, attribute)
+
+    def __init__(
+        self,
+        oauth_url: str = "https://www.linkedin.com/oauth/",
+        linkedin_url: str = "https://api.linkedin.com/",
+        session: Union[Session, requests.Session, None] = None,
+    ):
+        """Create an instance of the Requestor class.
+
+        :param oauth_url: (Optional) The URL used to make OAuth requests to the linkedin
+            site. (Default: https://oauth.linkedin.com)
+        :param linkedin_url: (Optional) The URL used when obtaining access tokens.
+            (Default: https://www.linkedin.com)
+        :param session: (Optional) A session to handle requests, compatible with
+            requests.Session(). (Default: None)
+        """
+        self._http = session or requests.Session()
+        self._http.headers["User-Agent"] = "pawl/0.0.2"
+        self.oauth_url = oauth_url
+        self.linkedin_url = linkedin_url
+
+    def close(self):
+        """Call close on the underlying session."""
+        return self._http.close()
+
+    def request(self, *args, timeout=TIMEOUT, **kwargs):
+        """Issue the HTTP request capturing any errors that may occur."""
+        try:
+            return self._http.request(*args, timeout=timeout, **kwargs)
+        except Exception as exc:
+            raise RequestException(exc, args, kwargs)

--- a/pawl/core/session.py
+++ b/pawl/core/session.py
@@ -1,0 +1,318 @@
+import logging
+import random
+import time
+from copy import deepcopy
+from urllib.parse import urljoin
+
+from requests.status_codes import codes
+from requests.exceptions import (
+    ChunkedEncodingError,
+    ConnectionError,
+    ReadTimeout,
+)
+
+from .auth import BaseAuthorizer
+from .rate_limit import RateLimiter
+from .constants import TIMEOUT
+from .exceptions import (
+    BadJSON,
+    BadRequest,
+    Conflict,
+    InvalidInvocation,
+    NotFound,
+    RequestException,
+    ServerError,
+    SpecialError,
+    TooLarge,
+    TooManyRequests,
+    URITooLong,
+)
+from .util import authorization_error_class
+
+log = logging.getLogger(__package__)
+
+
+class RetryStrategy:
+    """An abstract class for scheduling request retries.
+
+    The strategy controls both the number and frequency of retry attempts.
+    Instances of this class are immutable.
+    """
+
+    def sleep(self):
+        """Sleep until we are ready to attempt the request."""
+        sleep_seconds = self._sleep_seconds()
+        if sleep_seconds is not None:
+            message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to retry"
+            log.debug(message)
+            time.sleep(sleep_seconds)
+
+
+class FiniteRetryStrategy(RetryStrategy):
+    """A ``RetryStrategy`` that retries requests a finite number of times."""
+
+    def _sleep_seconds(self):
+        if self._retries < 3:
+            base = 0 if self._retries == 2 else 2
+            return base + 2 * random.random()
+        return None
+
+    def __init__(self, retries: int = 3):
+        """Initialize the strategy.
+
+        :param retries: Number of times to attempt a request.
+        """
+        self._retries = retries
+
+    def consume_available_retry(self):
+        """Allow one fewer retry."""
+        return type(self)(self._retries - 1)
+
+    def should_retry_on_failure(self):
+        """Return ``True`` if and only if the strategy will allow another retry."""
+        return self._retries > 1
+
+
+class Session:
+    """The low-level connection interface to Linkedin's API."""
+
+    RETRY_EXCEPTIONS = (ChunkedEncodingError, ConnectionError, ReadTimeout)
+    RETRY_STATUSES = {
+        520,
+        522,
+        codes["bad_gateway"],
+        codes["gateway_timeout"],
+        codes["internal_server_error"],
+        codes["service_unavailable"],
+    }
+    STATUS_EXCEPTIONS = {
+        codes["bad_gateway"]: ServerError,
+        codes["bad_request"]: BadRequest,
+        codes["conflict"]: Conflict,
+        codes["forbidden"]: authorization_error_class,
+        codes["gateway_timeout"]: ServerError,
+        codes["internal_server_error"]: ServerError,
+        codes["media_type"]: SpecialError,
+        codes["not_found"]: NotFound,
+        codes["request_entity_too_large"]: TooLarge,
+        codes["request_uri_too_large"]: URITooLong,
+        codes["service_unavailable"]: ServerError,
+        codes["too_many_requests"]: TooManyRequests,
+        codes["unauthorized"]: authorization_error_class,
+        520: ServerError,
+        522: ServerError,
+    }
+    SUCCESS_STATUSES = {codes["accepted"], codes["created"], codes["ok"]}
+
+    @staticmethod
+    def _log_request(data, method: str, params: dict, url: str):
+        log.debug(f"Fetching: {method} {url}")
+        log.debug(f"Data: {data}")
+        log.debug(f"Params: {params}")
+
+    def __init__(self, authorizer: BaseAuthorizer):
+        """Prepare the connection to Linkedin's API.
+
+        :param authorizer: An instance of :class:`Authorizer`.
+        """
+        if not isinstance(authorizer, BaseAuthorizer):
+            raise InvalidInvocation(f"Invalid Authorizer: {authorizer}")
+        self._authorizer = authorizer
+        self._rate_limiter = RateLimiter()
+        self._retry_strategy_class = FiniteRetryStrategy
+
+    def __enter__(self):
+        """Allow this object to be used as a context manager."""
+        return self
+
+    def __exit__(self, *_args):
+        """Allow this object to be used as a context manager."""
+        self.close()
+
+    def _do_retry(
+        self,
+        data,
+        json,
+        method,
+        params,
+        response,
+        retry_strategy_state,
+        saved_exception,
+        timeout,
+        url,
+    ):
+        if saved_exception:
+            status = repr(saved_exception)
+        else:
+            status = response.status_code
+        log.warning(f"Retrying due to {status} status: {method} {url}")
+        return self._request_with_retries(
+            data=data,
+            json=json,
+            method=method,
+            params=params,
+            timeout=timeout,
+            url=url,
+            retry_strategy_state=retry_strategy_state.consume_available_retry(),  # noqa: E501
+        )
+
+    def _make_request(
+        self,
+        data,
+        json,
+        method,
+        params,
+        retry_strategy_state,
+        timeout,
+        url,
+    ):
+        try:
+            response = self._rate_limiter.call(
+                self._requestor.request,
+                self._set_header_callback,
+                method,
+                url,
+                allow_redirects=False,
+                data=data,
+                json=json,
+                params=params,
+                timeout=timeout,
+            )
+            log.debug(
+                f"Response: {response.status_code}"
+                f" ({response.headers.get('content-length')} bytes)"
+            )
+            return response, None
+        except RequestException as exception:
+            if (
+                not retry_strategy_state.should_retry_on_failure()
+                or not isinstance(  # noqa: E501
+                    exception.original_exception, self.RETRY_EXCEPTIONS
+                )
+            ):
+                raise
+            return None, exception.original_exception
+
+    def _request_with_retries(
+        self,
+        data,
+        json,
+        method,
+        params,
+        timeout,
+        url,
+        retry_strategy_state=None,
+    ):
+        if retry_strategy_state is None:
+            retry_strategy_state = self._retry_strategy_class()
+
+        retry_strategy_state.sleep()
+        self._log_request(data, method, params, url)
+        response, saved_exception = self._make_request(
+            data,
+            json,
+            method,
+            params,
+            retry_strategy_state,
+            timeout,
+            url,
+        )
+
+        do_retry = False
+        if response is not None and response.status_code == codes["unauthorized"]:
+            self._authorizer._clear_access_token()
+            if hasattr(self._authorizer, "refresh"):
+                do_retry = True
+
+        if retry_strategy_state.should_retry_on_failure() and (
+            do_retry or response is None or response.status_code in self.RETRY_STATUSES
+        ):
+            return self._do_retry(
+                data,
+                json,
+                method,
+                params,
+                response,
+                retry_strategy_state,
+                saved_exception,
+                timeout,
+                url,
+            )
+        elif response.status_code in self.STATUS_EXCEPTIONS:
+            raise self.STATUS_EXCEPTIONS[response.status_code](response)
+        elif response.status_code == codes["no_content"]:
+            return
+        assert (
+            response.status_code in self.SUCCESS_STATUSES
+        ), f"Unexpected status code: {response.status_code}"
+        if response.headers.get("content-length") == "0":
+            return ""
+        try:
+            return response.json()
+        except ValueError:
+            raise BadJSON(response)
+
+    def _set_header_callback(self):
+        if not self._authorizer.is_valid():  # and hasattr(self._authorizer, "refresh"):
+            self._authorizer.refresh()
+        return {
+            "Authorization": f"Bearer {self._authorizer.access_token}",
+            "X-Restli-Protocol-Version": "2.0.0",
+        }
+
+    @property
+    def _requestor(self):
+        return self._authorizer._authenticator._requestor
+
+    def close(self):
+        """Close the session and perform any clean up."""
+        self._requestor.close()
+
+    def request(
+        self,
+        method,
+        path,
+        data=None,
+        json=None,
+        params=None,
+        timeout=TIMEOUT,
+    ):
+        """Return the json content from the resource at ``path``.
+
+        :param method: The request verb. E.g., get, post, put.
+        :param path: The path of the request. This path will be combined with the
+            ``oauth_url`` of the Requestor.
+        :param data: Dictionary, bytes, or file-like object to send in the body of the
+            request.
+        :param json: Object to be serialized to JSON in the body of the request.
+        :param params: The query parameters to send with the request.
+        Automatically refreshes the access token if it becomes invalid and a refresh
+        token is available. Raises InvalidInvocation in such a case if a refresh token
+        is not available.
+        """
+        # TODO - test
+        params = deepcopy(params) or {}
+        if isinstance(data, dict):
+            data = deepcopy(data)
+            data["api_type"] = "json"
+            data = sorted(data.items())
+        if isinstance(json, dict):
+            json = deepcopy(json)
+            json["api_type"] = "json"
+        url = urljoin(self._requestor.linkedin_url, path)
+        return self._request_with_retries(
+            data=data,
+            json=json,
+            method=method,
+            params=params,
+            timeout=timeout,
+            url=url,
+        )
+
+
+def session(authorizer=None):
+    """Return a :class:`Session` instance.
+
+    :param authorizer: An instance of :class:`Authorizer`.
+    """
+    return Session(authorizer=authorizer)

--- a/pawl/core/util.py
+++ b/pawl/core/util.py
@@ -1,0 +1,32 @@
+from .exceptions import (
+    ExpiredToken,
+    Forbidden,
+    InsufficientScope,
+    InvalidToken,
+    MissingToken,
+    RevokedToken,
+    UnknownAuthSchema,
+)
+
+_auth_error_mapping = {
+    403: Forbidden,
+    "insufficient_scope": InsufficientScope,
+    "Invalid access token": InvalidToken,
+    "Empty oauth2_access_token": MissingToken,
+    "Expired access token": ExpiredToken,
+    "The token has been revoked": RevokedToken,
+    "Unknown authentication schema": UnknownAuthSchema,
+}
+
+
+def authorization_error_class(response):
+    """Return an exception instance that maps to the OAuth2 Error.
+
+    :param response: The HTTP response containing an authentication error.
+    """
+    error = response.json()
+    if error:
+        error = error["message"]
+    else:
+        error = response["status"]
+    return _auth_error_mapping[error](response)

--- a/pawl/linkedin.py
+++ b/pawl/linkedin.py
@@ -1,10 +1,120 @@
 """Provide the Linkedin class."""
+from typing import Optional, Union, IO, Any, Dict, List
+
 from . import service
+from .core.auth import Authorizer, Authenticator  # noqa
+from .core.requestor import Requestor
+from .core.session import session
 
 
 class Linkedin:
     """The Linkedin class provides convenient access to Linkedin's API."""
 
-    def __init__(self, access_token=None):
-        self.me = service.Me(access_token)
-        # self.auth = service.Auth()
+    def __init__(
+        self,
+        access_token=None,
+        client_id=None,
+        client_secret=None,
+        redirect_uri="http://localhost:8000",
+        token_manager=None,
+    ):
+        assert access_token or (
+            client_id and client_secret
+        ), "Either client_id and client_secret or an access token is required."
+
+        self._core = self._authorized_core = None
+
+        # TODO - Abstract these values for security
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._redirect_uri = redirect_uri
+        # TODO END
+
+        self._services = None
+        self._token_manager = token_manager
+
+        self._map_services()
+        self._prepare_core()
+
+        self.auth = service.Auth(self, None)
+
+        self.current_user = service.Me(linkedin=self, _data=None)
+
+    def _prepare_core(self, requestor_class=None, requestor_kwargs=None):
+        requestor_class = requestor_class or Requestor
+        requestor_kwargs = requestor_kwargs or {}
+
+        requestor = requestor_class()
+        self._prepare_core_authenticator(requestor)
+
+    def _prepare_core_authenticator(self, requestor):
+        authenticator = Authenticator(
+            requestor, self._client_id, self._client_secret, self._redirect_uri
+        )
+        self._prepare_core_authorizer(authenticator)
+
+    def _prepare_core_authorizer(self, authenticator: Authenticator):
+        if self._token_manager is not None:
+            self._token_manager.linkedin = self
+            authorizer = Authorizer(
+                authenticator,
+                post_refresh_callback=self._token_manager.post_refresh_callback,
+                pre_refresh_callback=self._token_manager.pre_refresh_callback,
+            )
+        else:
+            # TODO - Add error handling
+            authorizer = Authorizer(authenticator)
+        self._core = self._authorized_core = session(authorizer)
+
+    def _map_services(self):
+        service_mappings = {
+            "Me": service.Me,
+            "Reactions": service.Reactions,
+        }
+        self._services = service_mappings
+
+    @staticmethod
+    def _parse_service_request(data: Optional[Union[Dict[str, Any], List[Any], bool]]):
+        # TODO - Restructure data for ease of use with python/utf-8
+        return data
+
+    def _service_request(
+        self,
+        data: Optional[Union[Dict[str, Union[str, Any]], bytes, IO, str]] = None,
+        json=None,
+        method: str = "",
+        params: Optional[Union[str, Dict[str, str]]] = None,
+        path: str = "",
+    ) -> Any:
+        """Run a request through mapped services.
+
+        :param data: Dictionary, bytes, or file-like object to send in the body of the
+            request (default: None).
+        :param json: JSON-serializable object to send in the body of the request with a
+            Content-Type header of application/json (default: None). If ``json`` is
+            provided, ``data`` should not be.
+        :param method: The HTTP method (e.g., GET, POST, PUT, DELETE).
+        :param params: The query parameters to add to the request (default: None).
+        :param path: The path to fetch.
+        """
+        return self._parse_service_request(
+            data=self._core.request(
+                data=data,
+                json=json,
+                method=method,
+                params=params,
+                path=path,
+            )
+        )
+
+    def get(
+        self,
+        path: str,
+        params: Optional[Union[str, Dict[str, Union[str, int]]]] = None,
+    ):
+        """Return parsed objects returned from a GET request to ``path``.
+
+        :param path: The path to fetch.
+        :param params: The query parameters to add to the request (default: None).
+        """
+        return self._service_request(method="GET", params=params, path=path)

--- a/pawl/service/auth.py
+++ b/pawl/service/auth.py
@@ -1,68 +1,76 @@
 """Provide `/authorization` service class."""
-import collections
+# import collections
 import hashlib
 import random
-import requests
 
-from urllib.parse import quote
+from enum import Enum
 
 from .base import ServiceBase
-from ..utils import raise_for_error
+from ..core import Authorizer, session
 
-AccessToken = collections.namedtuple("AccessToken", ["access_token", "expires_in"])
+# AccessToken = collections.namedtuple("AccessToken", ["access_token", "expires_in"])
+
+
+# TODO - Refactor permissions handling
+class AuthPermissions(Enum):
+    BASIC_PROFILE = "r_liteprofile"
+    EMAIL_ADDRESS = "r_emailaddress"
+    MEMBER_SOCIAL = "w_member_social"
+
+    @staticmethod
+    def to_oauth_scope():
+        return [scope.value for scope in list(AuthPermissions)]
 
 
 class Auth(ServiceBase):
     """Auth is a Service class that represents the `/authorization` endpoint."""
 
-    """Implement a standard OAuth 2.0 flow."""
+    def authorize(self, code: str):
+        authenticator = self._linkedin._authorized_core._authorizer._authenticator
+        authorizer = Authorizer(authenticator)
+        authorizer.authorize(code)
+        authorized_session = session.session(authorizer)
+        self._linkedin._core = self._linkedin._authorized_core = authorized_session
+        # TODO - create class for tokens
+        return authorizer.refresh_token
 
-    AUTHORIZATION_URL = "https://www.linkedin.com/oauth/v2/authorization"
-    ACCESS_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
-
-    def __init__(self, key, secret, redirect_uri, permissions=None):
-        self.key = key
-        self.secret = secret
-        self.redirect_uri = redirect_uri
-        self.permissions = permissions or []
-        self.state = None
-        self.authorization_code = None
-        self.token = None
-        self._error = None
-
-    @property
-    def authorization_url(self):
-        qd = {
-            "response_type": "code",
-            "client_id": self.key,
-            "scope": (" ".join(self.permissions)).strip(),
-            "state": self.state or self._make_new_state(),
-            "redirect_uri": self.redirect_uri,
-        }
-
-        qsl = ["%s=%s" % (quote(k), quote(v)) for k, v in qd.items()]
-        return "%s?%s" % (self.AUTHORIZATION_URL, "&".join(qsl))
-
-    @property
-    def last_error(self):
-        return self._error
+    def url(
+        self,
+        scopes: list[str] = None,
+        state: str = None,
+    ) -> str:
+        """Return the URL used out-of-band to grant access to your application."""
+        authenticator = self._linkedin._authorized_core._authorizer._authenticator
+        return authenticator.authorize_url(
+            scopes=scopes or AuthPermissions.to_oauth_scope(),
+            state=state or self._make_new_state(),
+        )
 
     def _make_new_state(self):
         return hashlib.md5(
-            "{}{}".format(random.randrange(0, 2 ** 63), self.secret).encode("utf8")
+            "{}{}".format(
+                random.randrange(0, 2 ** 63), self._linkedin._client_secret
+            ).encode("utf8")
         ).hexdigest()
 
-    def get_access_token(self, timeout=60):
-        assert self.authorization_code, "You must first get the authorization code"
-        qd = {
-            "grant_type": "authorization_code",
-            "code": self.authorization_code,
-            "redirect_uri": self.redirect_uri,
-            "client_id": self.key,
-            "client_secret": self.secret,
-        }
-        response = requests.post(self.ACCESS_TOKEN_URL, data=qd, timeout=timeout)
-        raise_for_error(response)
-        response = response.json()
-        self.token = AccessToken(response["access_token"], response["expires_in"])
-        return self.token
+    # TODO - incorporate utils' raise for error into this class and extend to other objects?
+    # def get_access_token(self, timeout=60):
+    #     assert (
+    #         self._linkedin._authorization_code
+    #     ), "You must first get the authorization code"
+    #     qd = {
+    #         "grant_type": "authorization_code",
+    #         "code": self._linkedin.authorization_code,
+    #         "redirect_uri": self._linkedin.redirect_uri,
+    #         "client_id": self._linkedin.client_id,
+    #         "client_secret": self._linkedin.client_secret,
+    #     }
+    #     response = self.make_request(
+    #         "POST", self.ACCESS_TOKEN_URL, data=qd, timeout=timeout
+    #     )
+    #     raise_for_error(response)
+    #     response = response.json()
+    #     self.access_token = AccessToken(
+    #         response["access_token"], response["expires_in"]
+    #     )
+    #     return self.access_token

--- a/pawl/service/base.py
+++ b/pawl/service/base.py
@@ -1,25 +1,57 @@
 """Provide the API's ServiceBase superclass."""
-import requests
+from copy import deepcopy
+from typing import TYPE_CHECKING, Optional, Any, Dict
+
+if TYPE_CHECKING:  # no cover
+    from ... import pawl
 
 
 class ServiceBase:
     """Superclass for all services in `linkedin/api`."""
 
-    def make_request(
-        self, method, url, data=None, params=None, headers=None, timeout=60
+    # TODO - confirm instance of self and complete logic (or reconsider approach for headers)
+    @property
+    def required_headers(self):
+        # if headers is None:
+        headers = {
+            "X-Restli-Protocol-Version": "2.0.0",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._linkedin.auth.access_token}",
+        }
+        # else:
+        # headers.update(
+        #     {
+        #         "X-Restli-Protocol-Version": "2.0.0",
+        #         "Content-Type": "application/json",
+        #     }
+        # )
+        return headers
+
+    @staticmethod
+    def _safely_add_arguments(argument_dict, key, **new_arguments):
+        """Replace argument_dict[key] with a deepcopy and update.
+
+        This method is often called when new parameters need to be added to a request.
+        By calling this method and adding the new or updated parameters we can insure we
+        don't modify the dictionary passed in by the caller.
+        """
+        value = deepcopy(argument_dict[key]) if key in argument_dict else {}
+        value.update(new_arguments)
+        argument_dict[key] = value
+
+    @classmethod
+    def parse(cls, data: Dict[str, Any], linkedin: "pawl.Linkedin") -> Any:
+        """Return an instance of ``cls`` from ``data``.
+
+        :param data: The structured data.
+        :param linkedin: An instance of :class:`.Linkedin`.
+        """
+        return cls(linkedin, _data=data)
+
+    def __init__(
+        self, linkedin: "pawl.Linkedin", _data: Optional[Dict[str, Any]] = None
     ):
-        if headers is None:
-            headers = {
-                "X-Restli-Protocol-Version": "2.0.0",
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.authentication.token.access_token}",
-            }
-        else:
-            headers.update(
-                {
-                    "X-Restli-Protocol-Version": "2.0.0",
-                    "Content-Type": "application/json",
-                }
-            )
-        kw = {"data": data, "params": params, "headers": headers, "timeout": timeout}
-        return requests.request(method.upper(), url, **kw)
+        self._linkedin = linkedin
+        if _data:
+            for attribute, value in _data.items():
+                setattr(self, attribute, value)

--- a/pawl/service/me.py
+++ b/pawl/service/me.py
@@ -1,20 +1,21 @@
 """Provide `/me` service class."""
 from .base import ServiceBase
 from ..constants import API_PATH
-from ..utils.raise_for_error import raise_for_error
+
+# from ..utils.raise_for_error import raise_for_error
 
 
 class Me(ServiceBase):
     """Me is a Service class that represents the `/me` endpoint."""
 
-    def __init__(self, access_token=None):
-        self.access_token = access_token
+    def basic_profile(self):
+        json_response = self._linkedin.get(path=f"v2/{API_PATH['me']}")
 
-    def get_basic_profile(self):
-        response = self.make_request(
-            "GET",
-            f"https://api.linkedin.com/v2/{API_PATH['me']}",
-            headers={"Authorization": "Bearer " + self.access_token},
-        )
-        raise_for_error(response)
-        return response.json()
+        """
+        TODO - Refactor object structure
+            - Return objects need to comform to module defined standards
+            - Apply error handle on object as attribute
+        """
+        # raise_for_error(response)
+
+        return json_response


### PR DESCRIPTION
## Summary

- [x] Add OAuth2 flow to obtain `access_token`.
    - `refresh_token` is **NOT** supported: my API does not have approval to work with them, so I would not be able to test it.
    - I will expose some methods in a future revision to help you manage them.
- [x] Refactor module into `core` and `pawl` for maintainability.

Closes #1 