### PR TITLE
release: v0.1.1

### DIFF
--- a/pawl/constants.py
+++ b/pawl/constants.py
@@ -1,6 +1,6 @@
 """Linkedin constants."""
 from .endpoints import API_PATH  # noqa
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 USER_AGENT_FORMAT = f"PAWL/{__version__}"

--- a/pawl/linkedin.py
+++ b/pawl/linkedin.py
@@ -138,6 +138,6 @@ class Linkedin:
         )
 
     def _set_linkedin_user_id(self):
-        if self._authorized_core._authorizer.access_token is not None:
+        if self._authorized_core._authorizer.access_token is None:
             return self.current_user.basic_profile()["id"]
         return None

--- a/tests/test_pawl.py
+++ b/tests/test_pawl.py
@@ -2,4 +2,4 @@ from pawl import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"


### PR DESCRIPTION
## Summary

- [x] Fix minor bug in `linkedin.py`'s `._set_linkedin_user_id()` method to set current_user_id to make an API call in order to set value on initialization.

## Notes

In future iterations, I will be considering how to refactor this code in order to minimize the number of calls made. Given that the average user's limit for such a request is 5,000 per day, I am not concerned at this time.